### PR TITLE
get_columns fix 

### DIFF
--- a/lib/DBIx/Class/AuditLog.pm
+++ b/lib/DBIx/Class/AuditLog.pm
@@ -23,7 +23,7 @@ sub insert {
     my ( $action, $table ) = $self->_action_setup( $result, 'insert' );
 
     if ($action) {
-        my %column_data = $result->get_columns;
+        my %column_data = map +($_ => $result->$_), $self->result_source->columns;
         $self->_store_changes( $action, $table, {}, \%column_data );
     }
 
@@ -38,7 +38,7 @@ sub update {
     my $self = shift;
 
     my $stored_row = $self->get_from_storage;
-    my %old_data   = $stored_row->get_columns;
+    my %old_data   = map +($_ => $stored_row->$_), $self->result_source->columns;
     my %new_data   = $self->get_dirty_columns;
 
     my $result = $self->next::method(@_);
@@ -83,7 +83,7 @@ sub delete {
     my ( $action, $table ) = $self->_action_setup( $stored_row, 'delete' );
 
     if ($action) {
-        my %old_data = $stored_row->get_columns;
+        my %old_data = map +($_ => $result->$_), $self->result_source->columns;
         $self->_store_changes( $action, $table, \%old_data, {} );
     }
 


### PR DESCRIPTION
get_columns is an internal method that returns values directly from storage.
This could break if FilterColumn is in use, as get_columns ignores filters that
are in place.

test suite passes.
