### PR TITLE
Don't die on cascaded updates to deleted rows.

### DIFF
--- a/lib/DBIx/Class/AuditLog.pm
+++ b/lib/DBIx/Class/AuditLog.pm
@@ -32,11 +32,14 @@ sub update {
     return $self->next::method(@_) if !$enabled;
 
     my $stored_row      = $self->get_from_storage;
-    my %old_data        = $stored_row->get_columns;
     my %new_data        = $self->get_columns;
     my @changed_columns = keys %{ $_[0] || {} };
 
     my $result = $self->next::method(@_);
+
+    return unless $stored_row; # update on deleted row - nothing to log
+
+    my %old_data = $stored_row->get_columns;
 
     if (@changed_columns) {
         @new_data{@changed_columns} = map $self->get_column($_),

--- a/t/011_update_on_deleted_row.t
+++ b/t/011_update_on_deleted_row.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+use DBICx::TestDatabase;
+use Test::More;
+
+use lib 't/lib';
+
+my $schema = DBICx::TestDatabase->new('AuditTestCascade::Schema');
+
+$schema->audit_log_schema->deploy;
+
+my $al_schema = $schema->audit_log_schema;
+
+is $al_schema->resultset('AuditLogChangeset')->count, 0, 'log is empty';
+
+$schema->populate('Title',[
+    [qw/id name/],
+    [qw/ 1 test/],
+]);
+$schema->populate('Book',[
+    [qw/id isbn/],
+    [qw/ 1 12345678/],
+]);
+
+my $title = $schema->resultset('Title')->first;
+$schema->txn_do(sub {
+    $title->book->delete;
+    $title->update({name => 'test2'}); # update cascades to deleted book
+});
+
+is $al_schema->resultset('AuditLogChangeset')->count, 1, 'One changeset logged';
+
+my $cset = $al_schema->resultset('AuditLogChangeset')->first ;
+is $cset->Action_rs->count, 2, 'Two actions logged';
+
+my $action = $cset->Action_rs->first;
+is $action->Change_rs->count, 2, 'Two changes logged';
+
+done_testing();

--- a/t/lib/AuditTestCascade/Schema.pm
+++ b/t/lib/AuditTestCascade/Schema.pm
@@ -1,0 +1,15 @@
+use utf8;
+
+package AuditTestCascade::Schema;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Schema';
+
+__PACKAGE__->load_components(qw/Schema::AuditLog/);
+
+__PACKAGE__->load_namespaces(
+    default_resultset_class => "+DBIx::Class::ResultSet::AuditLog" );
+
+1;

--- a/t/lib/AuditTestCascade/Schema/Result/Book.pm
+++ b/t/lib/AuditTestCascade/Schema/Result/Book.pm
@@ -1,0 +1,30 @@
+package AuditTestCascade::Schema::Result::Book;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->load_components('AuditLog');
+
+__PACKAGE__->table('book');
+
+__PACKAGE__->add_columns(
+	"id",
+	{
+		data_type => "integer",
+		extra => { unsigned => 1 },
+		is_auto_increment => 1,
+		is_nullable => 0,
+	},
+	"isbn",
+	{ data_type => "varchar", default_value => "", is_nullable => 0, size => 32 },
+);
+
+__PACKAGE__->set_primary_key("id");
+
+__PACKAGE__->belongs_to(
+  "title",
+   "AuditTestCascade::Schema::Result::Title",
+   { "id" => "id" },
+);
+
+1;
+

--- a/t/lib/AuditTestCascade/Schema/Result/Title.pm
+++ b/t/lib/AuditTestCascade/Schema/Result/Title.pm
@@ -1,0 +1,34 @@
+package AuditTestCascade::Schema::Result::Title;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->load_components('AuditLog');
+
+__PACKAGE__->table('title');
+
+__PACKAGE__->add_columns(
+    "id",
+    {   data_type         => "integer",
+        extra             => { unsigned => 1 },
+        is_auto_increment => 1,
+        is_nullable       => 0,
+    },
+    "name",
+    {   data_type     => "varchar",
+        default_value => "",
+        is_nullable   => 0,
+        size          => 32
+    },
+);
+
+__PACKAGE__->set_primary_key("id");
+
+__PACKAGE__->might_have(
+    "book",
+    "AuditTestCascade::Schema::Result::Book",
+    { "foreign.id" => "self.id" },
+);
+
+__PACKAGE__->add_unique_constraint( "name", ["name"] );
+
+1;


### PR DESCRIPTION
DBIx::Class cascades updates by default on has_one and might_have relationships. If in the same transaction the related row got deleted and would be affected by a cascaded update, AuditLog dies with an DBIx::Class::Schema::AuditLog::txn_do(): Can't call method "get_columns" on an undefined value at /usr/lib/perl5/site_perl/5.16.0/DBIx/Class/AuditLog.pm line 31. This happens because AuditLog tries to fetch the row freshly from the database and tries to access its data. Commit 4f09d5781c8e30b57436f567f07b6024e8c227ab fixes this.
