### PR TITLE
Bug: _force_audit method is not checking for whether the column is a valid column

### DIFF
--- a/lib/DBIx/Class/AuditLog.pm
+++ b/lib/DBIx/Class/AuditLog.pm
@@ -159,8 +159,9 @@ sub _force_audit {
     return unless $self->has_column($column);
 
     my $info = $self->column_info($column);
-    return defined $info->{force_audit_log_column};
 
+    return defined $info->{force_audit_log_column}
+        && $info->{force_audit_log_column};
 }
 
 sub _do_audit {

--- a/lib/DBIx/Class/AuditLog.pm
+++ b/lib/DBIx/Class/AuditLog.pm
@@ -154,6 +154,10 @@ sub _store_changes {
 sub _force_audit {
     my ( $self, $column ) = @_;
 
+    ## make sure that this is an actual column, and is not
+    ## a correlated column
+    return unless $self->has_column($column);
+
     my $info = $self->column_info($column);
     return defined $info->{force_audit_log_column};
 


### PR DESCRIPTION
Not everything that is returned by `get_columns` is an actual valid column name.

When using `DBIx::Class::Helper::ResultSet::CorrelateRelationship` the data is also stored together with columns, but it is not a valid column.

Trying to call `column_info` on an invalid column results in death by "column does not exist".

Second commit simply fixes a small issue where you can have `force_audit_log_column => 0`, which is, of course, silly, it is a possibility. However, that would pass `defiend`, as the key is defined, just set to zero.

